### PR TITLE
Fix matcher variable for latest master

### DIFF
--- a/gondolin.elv
+++ b/gondolin.elv
@@ -10,7 +10,7 @@ use re
 # -----------------------------------------------------------------------------
 
 # case-insensitive smart completion
-edit:-matcher[''] = [p]{ edit:match-prefix &smart-case $p }
+edit:completion:matcher[''] = [p]{ edit:match-prefix &smart-case $p }
 
 # -----------------------------------------------------------------------------
 # Utility Functions


### PR DESCRIPTION
Very nice theme!

$edit:-matcher has been renamed to $edit:completion:matcher since March 2018, it's a minor change.